### PR TITLE
Замена проверки errors на is_valid

### DIFF
--- a/celery_rpc/tasks.py
+++ b/celery_rpc/tasks.py
@@ -168,7 +168,7 @@ class ModelChangeTask(ModelTask):
                                            allow_add_remove=allow_add_remove,
                                            partial=partial)
 
-        if not serializer.errors:
+        if serializer.is_valid():
             serializer.save(force_insert=force_insert,
                             force_update=force_update)
             return serializer.data


### PR DESCRIPTION
Изменение нужно для оборачивания в сериалайзерах save и is_valid в force_master_read (errors - property и его обернуть сложнее).
Добавлять возможность переопределения базового сериалайзера пока не стала - мы можем обойтись и без нее. Но если нужно, могу добавить.
