### PR TITLE
Drop celery-3.1 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,14 @@
 envlist =
     {py3.8,py3.9,py3.10}-django{4.0}-drf{3.11,3.12,3.13}-celery{5.2}
     {py3.7,py3.8,py3.9,py3.10}-django{3.2}-drf{3.11,3.12,3.13}-celery{5.2}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.2}-drf{3.11,3.12,3.13}-celery{3.1,4.4,5.0,5.1}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.1}-drf{3.11,3.12,3.13}-celery{3.1,4.4,5.0,5.1}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.0}-drf{3.10,3.11,3.12,3.13}-celery{3.1,4.4,5.0,5.1}
-    {py3.5,py3.6,py3.7,py3.8,py3.10}-django{2.2}-drf{3.10,3.11,3.12}-celery{3.1,4.4}
-    {py3.5,py3.6,py3.7,py3.8}-django{2.1}-drf{3.10,3.11}-celery{3.1,4.4}
-    {py3.5,py3.6,py3.7,py3.8}-django{2.0}-drf{3.10,3.11}-celery{3.1,4.4}
-    {py2.7,py3.5}-django{1.11}-drf{3.7,3.6,3.5}-celery{3.1,4.4}
-    {py2.7,py3.5}-django{1.10}-drf{3.4,3.3}-celery{3.1}
-    {py2.7,py3.5}-django{1.9}-drf{3.4,3.3,3.2,3.1}-celery{3.1}
-    {py2.7,py3.5}-django{1.8}-drf{3.4,3.3,3.2,3.1,3.0,2.4}-celery{3.1}
-    py2.7-django{1.7}-drf{3.3,3.2,3.1,3.0,2.4,2.3}-celery{3.1}
-    py2.7-django{1.6}-drf{3.2,3.1,3.0,2.4,2.3}-celery{3.1}
-    py2.7-django{1.5}-drf{2.4,2.3}-celery{3.1}
-    py2.7-django{1.4}-drf{2.3}-celery{3.1}
-    py2.7-django{1.3}-drf{2.3}-celery{3.1}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.2}-drf{3.11,3.12,3.13}-celery{4.4,5.0,5.1}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.1}-drf{3.11,3.12,3.13}-celery{4.4,5.0,5.1}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-django{3.0}-drf{3.10,3.11,3.12,3.13}-celery{4.4,5.0,5.1}
+    {py3.5,py3.6,py3.7,py3.8,py3.10}-django{2.2}-drf{3.10,3.11,3.12}-celery{4.4}
+    {py3.5,py3.6,py3.7,py3.8}-django{2.1}-drf{3.10,3.11}-celery{4.4}
+    {py3.5,py3.6,py3.7,py3.8}-django{2.0}-drf{3.10,3.11}-celery{4.4}
+    {py2.7,py3.5}-django{1.11}-drf{3.7,3.6,3.5}-celery{4.4}
+
 
 [gh-actions]
 python =
@@ -38,22 +31,6 @@ basepython =
     py3.9: python3.9
     py3.10: python3.10
 deps =
-    django1.3: Django>=1.3,<1.4
-    django1.3: django-nose==1.4.3
-    django1.4: Django>=1.4,<1.5
-    django1.4: django-nose==1.4.3
-    django1.5: Django>=1.5,<1.6
-    django1.5: django-nose==1.4.3
-    django1.6: Django>=1.6,<1.7
-    django1.6: django-nose==1.4.3
-    django1.7: Django>=1.7,<1.8
-    django1.7: django-nose==1.4.3
-    django1.8: Django>=1.8,<1.9
-    django1.8: django-nose==1.4.3
-    django1.9: Django>=1.9,<1.10
-    django1.9: django-nose==1.4.3
-    django1.10: Django>=1.10,<1.11
-    django1.10: django-nose==1.4.4
     django1.11: Django>=1.11,<2.0
     django2.0: Django>=2.0,<2.1
     django2.1: Django>=2.1,<2.2
@@ -78,7 +55,6 @@ deps =
     drf3.11: djangorestframework>=3.11,<3.12
     drf3.12: djangorestframework>=3.12,<3.13
     drf3.13: djangorestframework>=3.13,<3.14
-    celery3.1: celery<4.0
     celery4.4: celery>=4.4,<4.5
     celery5.0: celery>=5.0,<5.1
     celery5.1: celery>=5.1,<5.2


### PR DESCRIPTION
Tox tests were broken because setuptools deprecates use2to3 param used in anyjson, which is transient dependency of Celery-3.1 through kombu.

Closes #144 